### PR TITLE
Material March and Parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/*
+entities/__pycache__/*
+properties/__pycache__/*

--- a/entities/material_entity.py
+++ b/entities/material_entity.py
@@ -1,22 +1,170 @@
 from ..export_params import ExportParams
 from .base_entity import BaseEntity
+import os
+import json
 
 class MaterialEntity(BaseEntity):
 
     def __init__(self, obj):
         super().__init__(obj)
+        
+    def santitize_image_name(self, image, output_dir):
+        
+        os.makedirs(output_dir + "/textures/", exist_ok=True)
+        
+        image.name = image.name.replace(".png","")+".png"
+        last3chars = image.name[len(image.name)-3:len(image.name)]
+        
+        # blender will append ".001" on an object name if it's name clashes with another. We want .png at the end.
+        # to combat this, we detect the .001 at the end (any number), then put it inside the name and append .png at the end.
+        if last3chars.isdigit() and image.name[len(image.name)-4:len(image.name)-3] == ".":
+            image.name = image.name[0:len(image.name)-3].replace(".png","")+last3chars+".png"
+        
+        originalpath = image.filepath
+        image.save(filepath=output_dir+"/textures/"+image.name)
+        
+        image.filepath = originalpath
+        
+        return "textures/"+image.name
+
+    def generate(self, output_dir = ""):
+        mat = self.obj
+            
+        #this is default data, as a reference to where I should shove things - @989onan
+        matdata = {
+            "materialVersion": 1,
+            "materials": [
+                {
+                    "albedo": [
+                        1,
+                        1,
+                        1
+                    ],
+                    "emissive": [
+                        0,
+                        0,
+                        0
+                    ],
+                    "scattering": 0,
+                    "cullFaceMode": "CULL_BACK"
+                }
+            ]
+        }
+        if not mat.use_nodes or not mat.node_tree:
+            return ""
+        tree = mat.node_tree
+        nodes = tree.nodes
+        
+        output = None
+        #find an output node with a principled going into it.
+        for n in nodes:
+            if n.type == 'OUTPUT_MATERIAL':
+                if len(n.inputs["Surface"].links) > 0:
+                    if n.inputs["Surface"].links[0].from_node:
+                        if n.inputs["Surface"].links[0].from_node.type == "BSDF_PRINCIPLED":
+                            output = n
+                            break
+        
+        if not output:
+            return ""
+        
+        principled = output.inputs["Surface"].links[0].from_node
+        matdata["materials"][0]["albedo"] = principled.inputs['Base Color'].default_value[:3]
+        matdata["materials"][0]["opacity"] = principled.inputs['Alpha'].default_value
+        matdata["materials"][0]["metallic"] = principled.inputs['Metallic'].default_value
+        matdata["materials"][0]["roughness"] = principled.inputs['Roughness'].default_value
+        matdata["materials"][0]["emissive"] = principled.inputs['Emission'].default_value[:3]
+        
+        try: 
+            base_color_source = principled.inputs["Base Color"].links[0].from_node
+            if base_color_source.type == "TEX_IMAGE":
+                matdata["materials"][0]["albedoMap"] = self.santitize_image_name(base_color_source.image, output_dir)
+        except Exception as e:
+            print(e)
+        
+        try: 
+            base_color_source = principled.inputs["Alpha"].links[0].from_node
+            if base_color_source.type == "TEX_IMAGE":
+                matdata["materials"][0]["opacityMap"] = self.santitize_image_name(base_color_source.image, output_dir)
+        except:
+            pass
+        
+        try: 
+            base_color_source = principled.inputs["Emission"].links[0].from_node
+            if base_color_source.type == "TEX_IMAGE":
+                matdata["materials"][0]["emissiveMap"] = self.santitize_image_name(base_color_source.image, output_dir)
+        except:
+            pass
+        
+        try: 
+            base_color_source = principled.inputs["Roughness"].links[0].from_node
+            if base_color_source.type == "TEX_IMAGE":
+                matdata["materials"][0]["roughnessMap"] = self.santitize_image_name(base_color_source.image, output_dir)
+            elif base_color_source.type == "INVERT":
+                matdata["materials"][0]["glossMap"] = self.santitize_image_name(base_color_source.links[1].from_node.image, output_dir)
+        except:
+            pass
+        
+        try: 
+            metallic_color_source = None
+            specular_color_source = None
+            try:
+                metallic_color_source = principled.inputs["Metallic"].links[0].from_node
+            except:
+                pass
+            try:
+                specular_color_source = principled.inputs["Specular"].links[0].from_node
+            except:
+                pass
+            
+            if metallic_color_source:
+                if metallic_color_source.type == "TEX_IMAGE":
+                    matdata["materials"][0]["metallicMap"] = self.santitize_image_name(metallic_color_source.image, output_dir)
+                    specular_color_source = None
+            if specular_color_source:
+                if specular_color_source.type == "TEX_IMAGE":
+                    matdata["materials"][0]["specularMap"] = self.santitize_image_name(specular_color_source.image, output_dir)
+        except:
+            pass
+        
+        try: 
+            normal_data_type = principled.inputs["Normal"].links[0].from_node
+            if normal_data_type.type == "NORMAL_MAP":
+                matdata["materials"][0]["normalMap"] = self.santitize_image_name(normal_data_type.links[1].from_node.image, output_dir)
+            elif normal_data_type.type == "BUMP":
+                matdata["materials"][0]["bumpMap"] = self.santitize_image_name(normal_data_type.links[2].from_node.image, output_dir)
+        except:
+            pass
+            
+        lightmapped_image_node = None
+        for n in nodes:
+            if n.type == 'OUTPUT_AOV':
+                if n.name == "Lightmap":
+                    if len(n.inputs["Color"].links) > 0:
+                        if n.inputs["Color"].links[0].from_node:
+                            if n.inputs["Color"].links[0].from_node.type == "TEX_IMAGE":
+                                lightmapped_image_node = n.inputs["Color"].links[0].from_node
+                                break
+        if lightmapped_image_node:
+            matdata["materials"][0]["lightMap"] = self.santitize_image_name(lightmapped_image_node.image, output_dir)
+        
+        self.obj.overte.material_data = json.dumps(matdata)
+        
 
     def get_material(self):
         material = {}
+        
+        if self.obj.overte.material_data != '':
+            material["materialData"] = json.loads(self.obj.overte.material_data)
+            self.obj.overte.material_data = ''
+            
+        
         if self.obj.overte.material_url != '':
             materialData = ExportParams.get_url(self.obj.overte.material_url)
             if self.obj.overte.material_url == 'materialData':
                 materialData = self.obj.overte.material_url
             material["materialURL"] = materialData
-
-        if self.obj.overte.material_data != '':
-            material["materialData"] = self.obj.overte.material_data
-
+        
         if self.obj.overte.material_priority != 0:
             material["priority"] = self.obj.overte.material_priority
 

--- a/entities/shape_entity.py
+++ b/entities/shape_entity.py
@@ -13,8 +13,7 @@ class ShapeBaseEntity(BaseEntity):
         try:
             obj = self.obj
             material = obj.material_slots[0].material
-            if material.overte.material_url != '':
-                return MaterialEntity(material)
+            return MaterialEntity(material)
         except:
             return None
 

--- a/export_overte_json.py
+++ b/export_overte_json.py
@@ -61,6 +61,7 @@ class ExportOverteJson(Operator, ExportHelper):
                 entity_json["parentID"] = parent.get_uuid()
                 entities.append(entity_json)
                 if material:
+                    material.generate(os.path.dirname(self.filepath))
                     material = material.export(entity_json)
                     entities.append(material)
 
@@ -87,6 +88,7 @@ class ExportOverteJson(Operator, ExportHelper):
                     entity_json["parentID"] = zone["id"]
                 entities.append(entity_json)
                 if material:
+                    material.generate(os.path.dirname(self.filepath))
                     material = material.export(entity_json)
                     entities.append(material)
 


### PR DESCRIPTION
This allows for the exporter to read Principled BSDF node setups from object materials and then export them to Json. It then exports the textures beside the json file the exporter makes for easy upload like it does for GLTFs